### PR TITLE
[DO NOT MERGE] Add missing configuration options

### DIFF
--- a/2.-Configuration.md
+++ b/2.-Configuration.md
@@ -50,6 +50,12 @@ We can disable the logging for all your services by using `-Dts.global.log.enabl
 
 By default logs are using ANSI colors, use `-Dts.global.log.nocolor=true` to disable them.
 
+# Service directory
+
+Services create their own folder under the `target` directory, which contains temporary files.
+If you want services to delete the folder on exit, set `ts.global.delete.folder.on.exit` configuration property to `true`.
+Alternatively, use `ts.<YOUR SERVICE NAME>.delete.folder.on.exit` for a specific service.
+
 # Timeouts
 
 Timeouts are quite important property to, as an example, control how long to wait for a service to start. The existing options to configure timeouts are:

--- a/8. Advanced-Quarkus-Modes.md
+++ b/8. Advanced-Quarkus-Modes.md
@@ -120,3 +120,45 @@ mvn clean verify -Dts.quarkus.cli.cmd="java -jar quarkus-cli.jar"
 ```
 
 The above command will use directly the binary from Quarkus upstream build.
+
+# Helm
+
+The framework supports testing the Quarkus Helm extension functionality.
+See the [extension documentation](https://quarkiverse.github.io/quarkiverse-docs/quarkus-helm/dev/index.html).
+
+Running `helm` and `helmfile` CLI is possible:
+```java
+@QuarkusScenario
+public class QuarkusHelmFileClientIT {
+
+    private static Path helmfilesFolder;
+
+    @Inject
+    static QuarkusHelmFileClient helmFileClient;
+
+    @BeforeAll
+    public static void tearUp() {
+        helmfilesFolder = Paths.get("src", "test", "resources", "helmfiles").toAbsolutePath();
+    }
+
+    @Test
+    public void verifyHelmFileInjection() {
+        QuarkusHelmFileClient.Result helmCmdResult = helmFileClient.run(helmfilesFolder.toAbsolutePath(), "-version");
+        assertTrue(
+                helmCmdResult.isSuccessful(),
+                String.format("Command %s fails", helmCmdResult.getCommandExecuted()));
+        assertFalse(
+                helmCmdResult.getOutput().isEmpty(),
+                "Unexpected helm version");
+    }
+}
+```
+
+The CLI tools, `helm` and `helmfile`, must be installed in the environment. For installation instructions, see:
+- https://helm.sh/docs/intro/install/
+- https://github.com/helmfile/helmfile#installation
+
+By default, Quarkus Test Framework expects the Helm / Helmfile tool to be available in CLI under the name `helm` / `helmfile`.
+However, if you have them installed under different names, you can take advantage of the following configuration properties:
+- `ts.quarkus.helm.cmd` - Specify name of Helm command.
+- `ts.quarkus.helmfile.cmd` - Specify name of Helmfile command.

--- a/9.-Scenario-Tracing-And-Metrics.md
+++ b/9.-Scenario-Tracing-And-Metrics.md
@@ -97,6 +97,12 @@ These are the basic metrics that are exposed:
 By default, when the metrics extension is enabled, the metrics are exported into the file `target/logs/metrics.out`. We can
 configure the output file using `-Dts.global.metrics.export.file.output=/to/metrics.out`.
 
+## Push policy
+
+By default, metrics are pushed after all tests within a class finish, analogous to the `@AfterAll` callback.
+You can change this behavior by setting the `ts.global.metrics.push-after-each-test` configuration property to `true`.
+This way, the push happens after each test, analogous to the `@AfterEach` callback.
+
 ## Prometheus Gateway
 
 In order to enable the Prometheus exported, you need to provide the following system properties:


### PR DESCRIPTION
Based on static code analysis - manual search for uses of `io.quarkus.test.configuration.PropertyLookup` and `io.quarkus.test.configuration.Configuration`.

Newly documented properties:
- `ts.global.delete.folder.on.exit`
- `ts.global.metrics.push-after-each-test`
- `ts.quarkus.helm.cmd`
- `ts.quarkus.helmfile.cmd`